### PR TITLE
Fix typo in handler.py

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -21,7 +21,7 @@ OK_RESPONSE = {
 ERROR_RESPONSE = {
     'statusCode': 400,
     'body': json.dumps('Oops, something went wrong!')
-
+}
     
 def configure_telegram():
     """


### PR DESCRIPTION
Since I am new to the whole serverless business it took me some time to figure out why my bot was failing when tried to bootstrap a project with this boilerplate code. It turned out to be a just a typo.